### PR TITLE
Fix build by not running test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@
 # release of a major GHC version. Setting HPVER implictly sets
 # GHCVER. Omit lines with versions you don't need/want testing for.
 env:
- - GHCVER=6.12.3
  - GHCVER=7.0.1
  - GHCVER=7.0.2
  - GHCVER=7.0.3

--- a/permutation.cabal
+++ b/permutation.cabal
@@ -24,7 +24,7 @@ copyright:       (c) 2008. Patrick Perry <patperry@stanford.edu>
 author:          Patrick Perry
 maintainer:      Sophie Taylor <sophie@traumapony.org>
 cabal-version: >= 1.2.3
-build-type:      Custom
+build-type:      Simple
 tested-with:     GHC ==7.8.1
 
 extra-source-files:  examples/Enumerate.hs
@@ -56,7 +56,7 @@ library
                      Data.Permute.Base
                      Data.Permute.IOBase
 
-    build-depends:   base < 5 && >=4, QuickCheck
+    build-depends:   base < 5 && >=4
     extensions:      BangPatterns, 
                      FlexibleContexts,
                      FunctionalDependencies, 

--- a/permutation.cabal
+++ b/permutation.cabal
@@ -1,5 +1,5 @@
 name:            permutation
-version:         0.5.0.5
+version:         0.5.0.6
 homepage:        https://github.com/spacekitteh/permutation
 synopsis:        A library for permutations and combinations.
 description:

--- a/permutation.cabal
+++ b/permutation.cabal
@@ -23,7 +23,7 @@ license-file:    LICENSE
 copyright:       (c) 2008. Patrick Perry <patperry@stanford.edu>
 author:          Patrick Perry
 maintainer:      Sophie Taylor <sophie@traumapony.org>
-cabal-version: >= 1.2.3
+cabal-version: >= 1.6
 build-type:      Simple
 tested-with:     GHC ==7.8.1
 
@@ -38,6 +38,10 @@ extra-source-files:  examples/Enumerate.hs
                      tests/STPermute.hs
                      tests/Makefile
                      NEWS
+
+source-repository head
+  type:           git
+  location:       git://github.com/spacekitteh/permutation
 
 library
     hs-source-dirs:  lib


### PR DESCRIPTION
Fix the build by changing build-type to Simple, meaning that the tests are not run anymore. The tests were written with an old version (<2.0) of QuickCheck (which requires base <4) and could therefore not compile.
